### PR TITLE
ENH: Display q2:types info in `tabulate` viz

### DIFF
--- a/q2_metadata/_tabulate.py
+++ b/q2_metadata/_tabulate.py
@@ -10,6 +10,8 @@ import os
 import pkg_resources
 import shutil
 
+import pandas as pd
+
 import qiime2
 import q2templates
 
@@ -23,6 +25,10 @@ def tabulate(output_dir: str, input: qiime2.Metadata,
         raise ValueError('Cannot render less than one record per page.')
 
     df = input.to_dataframe()
+    df_columns = pd.MultiIndex.from_tuples(
+        [(n, t.type) for n, t in input.columns.items()],
+        names=['column header', 'type'])
+    df.columns = df_columns
     df.reset_index(inplace=True)
     table = df.to_json(orient='split')
     # JSON spec doesn't allow single quotes in string values, at all. It does

--- a/q2_metadata/templates/tabulate/index.html
+++ b/q2_metadata/templates/tabulate/index.html
@@ -13,6 +13,8 @@
   <script type="text/javascript">
     $(document).ready(function(){
       var data = JSON.parse('{{ table }}');
+      // Manually set the directive label
+      data.columns[0][1] = '#q2:types';
       var filename = 'metadata';
       var table = $('#table'), head = $('<thead></thead>'), row = $('<tr></tr>');
       table.append(head);
@@ -21,7 +23,7 @@
         row.append(function() {
           var cell = '<th>' + val[0] + '<br>';
           if (i === 0) {
-            cell += '<span class="label label-default">#q2:types</span>';
+            cell += '<span class="label label-default">' + val[1]  + '</span>';
           } else {
             var type = val[1] === 'numeric' ? 'primary' : 'success';
             cell += '<span class="label label-' + type + '">' + val[1] +'</span>';
@@ -31,17 +33,24 @@
         });
       });
 
+      var cleanDirectives = function(delimiter) {
+        return function(exportData) {
+          exportData = exportData.split('\n');
+          exportData.unshift(data[0]);  // duplicate first row to stash the types directive in
+          exportData[0] = $.map(data.columns, function(c) { return '\"' + c[0] + '\"'; }).join(delimiter);
+          exportData[1] = $.map(data.columns, function(c) { return '\"' + c[1] + '\"'; }).join(delimiter);
+          return exportData.join('\n');
+        }
+      }
+
       table.DataTable({
         data: data.data,
         fixedHeader: true,
         pageLength: {{ page_size }},
         dom: 'Bfrtip',
         buttons: [
-          { extend: 'csv', filename: filename, text: 'TSV', fieldSeparator: '\t', extension: '.tsv' },
-          { extend: 'csv', filename: filename },
-          { extend: 'excel', filename: filename },
-          { extend: 'copy', fieldBoundary: '"' },
-          'print',
+          { extend: 'csv', filename: filename, text: 'TSV', fieldSeparator: '\t', extension: '.tsv', customize: cleanDirectives('\t'), },
+          { extend: 'csv', filename: filename , customize: cleanDirectives(','), },
         ],
       });
     });

--- a/q2_metadata/templates/tabulate/index.html
+++ b/q2_metadata/templates/tabulate/index.html
@@ -12,13 +12,28 @@
 
   <script type="text/javascript">
     $(document).ready(function(){
-      var table = JSON.parse('{{ table }}');
-      var columns = $.map(table.columns, function(val) { return { title: val }; });
+      var data = JSON.parse('{{ table }}');
       var filename = 'metadata';
+      var table = $('#table'), head = $('<thead></thead>'), row = $('<tr></tr>');
+      table.append(head);
+      head.append(row);
+      $.each(data.columns, function(i, val) {
+        row.append(function() {
+          var cell = '<th>' + val[0] + '<br>';
+          if (i === 0) {
+            cell += '<span class="label label-default">#q2:types</span>';
+          } else {
+            var type = val[1] === 'numeric' ? 'primary' : 'success';
+            cell += '<span class="label label-' + type + '">' + val[1] +'</span>';
+          }
+          cell += '</th>';
+          return cell;
+        });
+      });
 
-      $('#table').DataTable({
-        data: table.data,
-        columns: columns,
+      table.DataTable({
+        data: data.data,
+        fixedHeader: true,
         pageLength: {{ page_size }},
         dom: 'Bfrtip',
         buttons: [

--- a/q2_metadata/tests/test_tabulate.py
+++ b/q2_metadata/tests/test_tabulate.py
@@ -31,7 +31,8 @@ class TabulateTests(TestCase):
             viz = open(index_fp).read()
 
             self.assertTrue('pageLength: 100' in viz)
-            self.assertTrue('"columns":["id","foo"]' in viz)
+            self.assertTrue('"columns":[["id",""],["foo","categorical"]]'
+                            in viz)
             self.assertTrue(all(i in viz for i in index))
             self.assertTrue(all(val in viz for val in data))
 
@@ -51,7 +52,9 @@ class TabulateTests(TestCase):
             viz = open(index_fp).read()
 
             self.assertTrue('pageLength: 100' in viz)
-            self.assertTrue('"columns":["id","foo","bar","baz"]' in viz)
+            self.assertTrue('"columns":[["id",""],["foo","categorical"],'
+                            '["bar","categorical"],["baz","categorical"]]'
+                            in viz)
             self.assertTrue(all(i in viz for i in index))
             self.assertTrue(all(v in viz for row in data for v in row))
 
@@ -68,7 +71,8 @@ class TabulateTests(TestCase):
 
             viz = open(index_fp).read()
             self.assertTrue('pageLength: 100' in viz)
-            self.assertTrue('"columns":["id","foo","bar"]' in viz)
+            self.assertTrue('"columns":[["id",""],["foo","numeric"],'
+                            '["bar","categorical"]]' in viz)
             self.assertTrue(all(i in viz for i in index))
             self.assertTrue(all(str(v) in viz for row in data for v in row))
 
@@ -109,7 +113,8 @@ class TabulateTests(TestCase):
             viz = open(index_fp).read()
 
             self.assertTrue('pageLength: 100' in viz)
-            self.assertTrue('"columns":["id","foo"]' in viz)
+            self.assertTrue('"columns":[["id",""],["foo","categorical"]]'
+                            in viz)
             self.assertTrue(all(i in viz for i in index))
             unicodified = [r'\u00271.0\u0027', r'\u00272.0\u0027',
                            r'\u00273.0\u0027']


### PR DESCRIPTION
Fixes #3 