### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/q2_metadata/_tabulate.py
+++ b/q2_metadata/_tabulate.py
@@ -20,7 +20,7 @@ TEMPLATES = pkg_resources.resource_filename('q2_metadata', 'templates')
 
 
 def tabulate(output_dir: str, input: qiime2.Metadata,
-             page_size: int=100) -> None:
+             page_size: int = 100) -> None:
     if page_size < 1:
         raise ValueError('Cannot render less than one record per page.')
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Numerous minor updates for compliance with flake8 v3.6, as discussed in qiime2/qiime2#415
Note: flake8 has been disabled in versioneer.py.