### PR TITLE
ci: quality-filter not needed in recipe

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -25,14 +25,12 @@ requirements:
     - qiime2 {{ qiime2_epoch }}.*
     - q2templates {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*
-    - q2-quality-filter {{ qiime2_epoch }}.*
 
 test:
   requires:
     - qiime2 >={{ qiime2 }}
     - q2templates >={{ q2templates }}
     - q2-types >={{ q2_types }}
-    - q2-quality-filter >={{ q2_quality_filter }}
     - pytest
 
   imports:


### PR DESCRIPTION
this PR removes quality filter from q2-metadata's recipe file. this is not a needed dep for this plugin and was added unintentionally during our usage example sprint in 2022.