### PR TITLE
bug: removes quality filter dep

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -25,14 +25,12 @@ requirements:
     - qiime2 {{ qiime2_epoch }}.*
     - q2templates {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*
-    - q2-quality-filter {{ qiime2_epoch }}.*
 
 test:
   requires:
     - qiime2 >={{ qiime2 }}
     - q2templates >={{ q2templates }}
     - q2-types >={{ q2_types }}
-    - q2-quality-filter >={{ q2_quality_filter }}
     - pytest
 
   imports:


### PR DESCRIPTION
this PR removes the quality filter dep caused by [this usage example PR](https://github.com/qiime2/q2-metadata/pull/49) that has since been removed b/c the juice isn't worth the squeeze dependency-wise.
